### PR TITLE
Issue-59 - upgrade library dependencies to latest versions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,7 +16,6 @@
   <url>https://www.lfenergy.org/projects/shapeshifter/</url>
 
   <properties>
-    <jaxb.version>4.0.0</jaxb.version>
     <jaxb40-maven-plugin.version>0.16.1</jaxb40-maven-plugin.version>
   </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,15 +22,12 @@
     <jna.version>5.13.0</jna.version>
     <lazysodium-java.version>5.1.4</lazysodium-java.version>
     <resource-loader.version>2.0.2</resource-loader.version>
-    <swagger-annotations.version>2.2.15</swagger-annotations.version>
-    <wiremock.version>2.35.0</wiremock.version>
+    <swagger-annotations.version>2.2.18</swagger-annotations.version>
+    <wiremock.version>3.2.0</wiremock.version>
     <xmlunit.verion>2.9.1</xmlunit.verion>
-    <jaxb.version>4.0.0</jaxb.version>
-    <lombok.version>1.18.28</lombok.version>
-    <commons-logging.version>1.0.2</commons-logging.version>
+    <lombok.version>1.18.30</lombok.version>
+    <commons-logging.version>1.2</commons-logging.version>
     <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
-    <junit.version>5.9.3</junit.version>
-    <mockito.version>5.2.0</mockito.version>
     <awaitility.version>4.2.0</awaitility.version>
   </properties>
 
@@ -118,12 +115,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${awaitility.version}</version>
@@ -136,8 +127,8 @@
     </dependency>
     <!-- Configure a test application without UftpConnector mapping test beans -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,25 +43,25 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <jaxb.version>4.0.0</jaxb.version>
+    <jaxb.version>4.0.1</jaxb.version>
 
     <!-- Test dependency versions -->
-    <junit.version>5.9.2</junit.version>
+    <junit.version>5.10.0</junit.version>
     <assertj.version>3.24.2</assertj.version>
-    <mockito.version>5.2.0</mockito.version>
+    <mockito.version>5.6.0</mockito.version>
 
     <!-- Plugin versions -->
-    <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
+    <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>3.2.1</maven-failsafe-plugin.version>
     <maven-jaxb2-plugin.version>0.15.2</maven-jaxb2-plugin.version>
-    <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
+    <dependency-check-maven.version>8.4.2</dependency-check-maven.version>
     <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
-    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-    <maven-release-plugin.version>3.0.0</maven-release-plugin.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-    <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
   </properties>
 
   <modules>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -16,8 +16,8 @@
   <url>https://www.lfenergy.org/projects/shapeshifter/</url>
 
   <properties>
-    <spring-boot.version>3.1.2</spring-boot.version>
-    <swagger-annotations.version>2.2.15</swagger-annotations.version>
+    <spring-boot.version>3.1.5</spring-boot.version>
+    <swagger-annotations.version>2.2.18</swagger-annotations.version>
   </properties>
 
   <dependencyManagement>
@@ -93,11 +93,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* Bumped several dependencies
* Removed `mockito-inline` - apparently this library has been merged back into `mockito-core`
* `wiremock` library has moved - update the group name