### PR TITLE
Key pair tool did not show output on console

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,8 @@
     <commons-logging.version>1.3.4</commons-logging.version>
     <jakarta-annotation.version>3.0.0</jakarta-annotation.version>
     <awaitility.version>4.2.1</awaitility.version>
+    <slf4j-api.version>2.0.12</slf4j-api.version>
+    <slf4j-simple.version>2.0.13</slf4j-simple.version>
   </properties>
 
   <dependencies>
@@ -47,6 +49,16 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j-api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j-simple.version}</version>
     </dependency>
 
     <dependency>
@@ -149,4 +161,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>maven_central</id>
+      <name>Maven Central</name>
+      <url>https://repo.maven.apache.org/maven2/</url>
+    </repository>
+  </repositories>
 </project>

--- a/core/src/main/java/org/lfenergy/shapeshifter/core/tools/UftpKeyPairTool.java
+++ b/core/src/main/java/org/lfenergy/shapeshifter/core/tools/UftpKeyPairTool.java
@@ -6,6 +6,7 @@ package org.lfenergy.shapeshifter.core.tools;
 
 import com.goterl.lazysodium.LazySodiumJava;
 import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.exceptions.SodiumException;
 import java.util.Base64;
 import lombok.val;
 import org.apache.commons.logging.LogFactory;
@@ -15,24 +16,14 @@ public class UftpKeyPairTool {
 
   public static void main(String[] args) {
     var log = LogFactory.getLog(UftpKeyPairTool.class);
+
     log.info("GOPACS UFTP Key Pair Tool");
     log.info("-------------------------");
-    log.info("Generating key pair...");
 
     val keypair = generateKeyPair();
 
-    log.info("\n");
-    log.info("Private Key:");
-    log.info("\n");
-    log.info(keypair.privateKey());
-
-    log.info("\n");
-    log.info("Public Key:");
-    log.info("\n");
-    log.info(keypair.publicKey());
-
-    log.info("\n");
-    log.info("All done!");
+    log.info("Private Key: " + keypair.privateKey());
+    log.info("Public Key : " + keypair.publicKey());
   }
 
   public static KeyPair generateKeyPair() {
@@ -42,7 +33,7 @@ public class UftpKeyPairTool {
       String base64Public = Base64.getEncoder().encodeToString(keyPair.getPublicKey().getAsBytes());
       String base64Secret = Base64.getEncoder().encodeToString(keyPair.getSecretKey().getAsBytes());
       return new KeyPair(base64Public, base64Secret);
-    } catch (Exception cause) {
+    } catch (SodiumException cause) {
       throw new UftpConnectorException("Failed to generate key pair.", cause);
     }
   }


### PR DESCRIPTION
When you run the key pair tool, it does not show any output on the console. This is done by adding SLF4j dependencies (needed by the commons-logging factory).
Also made the output of the tool a bit more compact by removing a couple of newlines.