### PR TITLE
Update spring boot te latest version and fix breaking annotations (#128)

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -16,7 +16,7 @@
   <url>https://www.lfenergy.org/projects/shapeshifter/</url>
 
   <properties>
-    <spring-boot.version>3.2.5</spring-boot.version>
+    <spring-boot.version>3.4.1</spring-boot.version>
     <swagger-annotations.version>2.2.21</swagger-annotations.version>
   </properties>
 

--- a/spring/src/main/java/org/lfenergy/shapeshifter/spring/config/ShapeshifterConfiguration.java
+++ b/spring/src/main/java/org/lfenergy/shapeshifter/spring/config/ShapeshifterConfiguration.java
@@ -61,7 +61,6 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public UftpSendMessageService uftpSendMessageService(UftpSerializer serializer,
                                                          UftpCryptoService cryptoService,
                                                          ParticipantResolutionService participantService,
@@ -72,7 +71,6 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public UftpCryptoService uftpCryptoService(ParticipantResolutionService participantService,
                                                LazySodiumFactory factory,
                                                LazySodiumBase64Pool lazySodiumInstancePool) {
@@ -87,7 +85,6 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public ReceivedMessageProcessor receivedMessageProcessor(UftpPayloadHandler payloadHandler,
                                                              DuplicateMessageDetection duplicateDetection,
                                                              UftpErrorProcessor errorProcessor) {
@@ -96,14 +93,12 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public UftpSerializer uftpSerializer(XsdValidator xsdValidator) {
         return new UftpSerializer(new XmlSerializer(), xsdValidator);
     }
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public ParticipantResolutionService participantResolutionService(UftpParticipantService uftpParticipantService) {
         return new ParticipantResolutionService(uftpParticipantService);
     }
@@ -121,7 +116,6 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public UftpValidationService uftpValidationService(ParticipantSupport participantSupport,
                                                        CongestionPointSupport congestionPointSupport,
                                                        DuplicateMessageDetection duplicateMessageDetection,
@@ -173,14 +167,12 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public DuplicateMessageDetection duplicateMessageDetection(UftpMessageSupport uftpMessageSupport) {
         return new DuplicateMessageDetection(uftpMessageSupport, new XmlSerializer());
     }
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public UftpReceivedMessageService uftpReceivedMessageService(UftpValidationService uftpValidationService,
                                                                  UftpPayloadHandler uftpPayloadHandler) {
         var uftpReceivedMessageService = new UftpReceivedMessageService(uftpValidationService, uftpPayloadHandler);
@@ -206,14 +198,12 @@ public class ShapeshifterConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public XsdValidator xsdValidator(XsdSchemaProvider xsdSchemaProvider) {
         return new XsdValidator(xsdSchemaProvider);
     }
 
     @ConditionalOnMissingBean
     @Bean
-    @Autowired
     public XsdSchemaProvider xsdSchemaProvider(XsdFactory xsdFactory) {
         return new XsdSchemaProvider(xsdFactory);
     }


### PR DESCRIPTION
Fixes in version 2.6.1 are not included in version 3.0.0. Cherry picked them and merging them to main for a 3.1.0 release including both changes.